### PR TITLE
Added DevelopWidget for Develop mode

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(Editor)
 add_subdirectory(Menus)
+add_subdirectory(Modes)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
@@ -19,4 +20,4 @@ include_directories(
 
 add_executable(ROSIDE ${ROSIDE_SRC_FILES})
 qt5_use_modules(${PROJECT_NAME} Widgets)
-target_link_libraries(ROSIDE Qt5::Core Qt5::Quick Editor Menus)
+target_link_libraries(ROSIDE Qt5::Core Qt5::Quick Editor Menus Modes)

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -6,6 +6,7 @@
 
 #include <MainWindow.h>
 #include <Editor/EditorWidget.h>
+#include <Modes/DevelopWidget.h>
 
 MainWindow& MainWindow::get() {
     static MainWindow instance;
@@ -32,7 +33,7 @@ MainWindow::MainWindow()
     main_tabbed_window_ = new QTabWidget(this);
     // Create tabs and store indexes in mode_tab_index_list_
     mode_tab_index_list_.insert(DESIGN, main_tabbed_window_->addTab(new QWidget(), tr("Design")));
-    mode_tab_index_list_.insert(DEVELOP, main_tabbed_window_->addTab(new EditorWidget(this), tr("Develop")));
+    mode_tab_index_list_.insert(DEVELOP, main_tabbed_window_->addTab(new DevelopWidget(main_tabbed_window_), tr("Develop")));
 
     main_tabbed_window_->setTabPosition(QTabWidget::West);
     main_tabbed_window_->show();

--- a/src/Modes/CMakeLists.txt
+++ b/src/Modes/CMakeLists.txt
@@ -1,0 +1,22 @@
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set( MODES_SRC_FILES
+        DevelopWidget.h
+        DevelopWidget.cpp
+        )
+
+find_package(Qt5 COMPONENTS Core Quick REQUIRED)
+
+include_directories(
+        ${QT_INCLUDES}
+        .
+        ..
+)
+
+
+add_library(Modes ${MODES_SRC_FILES})
+
+qt5_use_modules(Modes Widgets)
+target_link_libraries(Modes Qt5::Core Qt5::Quick Editor)

--- a/src/Modes/DevelopWidget.cpp
+++ b/src/Modes/DevelopWidget.cpp
@@ -1,0 +1,23 @@
+//
+// Created by cjreid on 3/17/18.
+//
+
+#include "DevelopWidget.h"
+
+#include <QDockWidget>
+#include <QTabWidget>
+#include <QTreeView>
+
+#include <Editor/EditorWidget.h>
+
+DevelopWidget::DevelopWidget(QWidget *parent)
+    : QMainWindow(parent) {
+
+    main_tab_widget_ = new QTabWidget(this);
+
+    setCentralWidget(main_tab_widget_);
+    main_tab_widget_->setTabPosition(QTabWidget::North);
+
+    main_tab_widget_->addTab(new EditorWidget(main_tab_widget_), "Test");
+
+}

--- a/src/Modes/DevelopWidget.h
+++ b/src/Modes/DevelopWidget.h
@@ -1,0 +1,23 @@
+//
+// Created by cjreid on 3/17/18.
+//
+
+#ifndef ROSIDE_DEVELOPWIDGET_H
+#define ROSIDE_DEVELOPWIDGET_H
+
+#include <QMainWindow>
+
+class QTabWidget;
+class QWidget;
+
+
+class DevelopWidget : public QMainWindow {
+    Q_OBJECT
+public:
+    DevelopWidget(QWidget *parent = 0);
+private:
+    QTabWidget *main_tab_widget_;
+};
+
+
+#endif //ROSIDE_DEVELOPWIDGET_H


### PR DESCRIPTION
Added class DevelopWidget which is the QMainWindow for development mode. In the future, it will support dockable windows (file tree views and such) which is what necessitates it inheriting QMainWindow.